### PR TITLE
try adding env variables directly in the deploy preview build command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,5 +5,8 @@
 [context.production.environment]
   WHO_AM_I = "World"
 
+[context.deploy-preview]
+  command = "WHO_AM_I=DeployPreview npm run build"
+
 [context.deploy-preview.environment]
   WHO_AM_I = "Developer"


### PR DESCRIPTION
This attempts to add environment variables DIRECTLY in the command being executed. This is basically doing the same thing as `env-cmd` (as tried in #2) would do it but just directly (minimal viable product).

e.g.

```
MY_ENV=STUFF npm run build
```

NOTE: there is no `&&` added nor use of `export`/`eval`